### PR TITLE
add missing RAIN weather type to config + update fx_version

### DIFF
--- a/config/ServerSync.lua
+++ b/config/ServerSync.lua
@@ -76,6 +76,7 @@ ss_weather_Transition = {
 	["CLEAR"]      = {"CLOUDS","EXTRASUNNY","CLEARING","SMOG","OVERCAST"},
 	["CLOUDS"]     = {"CLEAR","SMOG","CLEARING","OVERCAST"},
 	["OVERCAST"]   = {"CLEAR","CLOUDS","SMOG","CLEARING","THUNDER"},
+	["RAIN"]	   = {"CLEAR", "OVERCAST", "CLOUDS", "CLEARING"},
 	["THUNDER"]    = {"OVERCAST"}, -- Always rotate away from Thunder, as it's annoying
 	["CLEARING"]   = {"CLEAR","CLOUDS","OVERCAST","SMOG"},
 	["SNOW"]       = {"SNOW","SNOWLIGHT"},  -- Usually used for events - never changes and has to be manually set via /weather command

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,7 +7,7 @@ author 'Wyste (https://github.com/Wyste) | (https://discordapp.com/invite/byNc6w
 version 'v1.0'
 url 'https://github.com/Wyste/ServerSync'
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
 client_scripts {


### PR DESCRIPTION
This PR adds the missing `RAIN` weather key to the `ss_weather_Transition` table and resolves the Invalid Weather error received when trying to set the weather to rain. Additionally it updates the fx_manifest to the latest fx_version,